### PR TITLE
Default Config wasn't working

### DIFF
--- a/grails-app/conf/DefaultArtefactMessagingConfig.groovy
+++ b/grails-app/conf/DefaultArtefactMessagingConfig.groovy
@@ -1,10 +1,1 @@
-grails.plugins.artefactmessaging {
-	// Map of artefact type (serviceClasses) to grails-app folder name/plugin name
-	//	(can be null value if there is no associated artefact folder in grails-app or plugin)
-	artefacts = [
-		[
-			name:"service",
-			plugin:"services",
-		],
-	]
-}
+artefactmessaging.artefacts = [[name:"service",plugin:"services"]]


### PR DESCRIPTION
Brian,

The default config for this wasn't working for me. I think I found the problem: in loadConfig of the plugin class you're doing a getProperty("artefactmessaging"), but the config file has "grails.plugins.artefactmessaging". I've corrected this in the default config, but I'd be fine with changing the plugin class too.

Thanks,
Nathan
